### PR TITLE
Fix aspect ratio of `medres` and `highres` Vimeo thumbnails

### DIFF
--- a/embedder/services/EmbedderService.php
+++ b/embedder/services/EmbedderService.php
@@ -146,8 +146,8 @@ class EmbedderService extends BaseApplicationComponent
             $video_info->thumbnail_url = str_replace('hqdefault','mqdefault',$video_info->thumbnail_url);
             }
         else if (strpos($video_url, "vimeo.com/") !== FALSE) {
-            $video_info->highres_url = str_replace('_295','_1280',$video_info->thumbnail_url);
-            $video_info->medres_url = str_replace('_295','_640',$video_info->thumbnail_url);
+            $video_info->highres_url = preg_replace('/_(.*?)\./','_1280.',$video_info->thumbnail_url);
+            $video_info->medres_url = preg_replace('/_(.*?)\./','_640.',$video_info->thumbnail_url);
             }
         else if (strpos($video_url, "wistia.com/") !== FALSE)
             {


### PR DESCRIPTION
Vimeo thumbnails would previously only alter the image width and not the height, resulting in wider and wider aspect ratios as the width increased from `thumbnail` to `medres` and `highres`. This fix removes the height component from the thumbnail URL letting Vimeo assign that automatically based on the original aspect ratio.
