### PR TITLE
adding Wistia specific options 'wistia_type' and 'wistia_foam'

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ If you're using Viddler, you get access to two more parameters:
 - viddler_type='simple/player' -- Specifies the player type. Defaults to player.
 - viddler_ratio='widescreen/fullscreen' -- Aspect ratio will be automatically determined if not set.
 
+If you're using Wistia, you get access to two more parameters:
+
+- wistia_type -- Sets the supported embed type
+- wistia_foam='true/false' -- Makes the embedded video responsive using Wistia's Video Foam feature
+
 Warranty/License
 ------
 There's no warranty of any kind. If you find a bug, please tell me and I may try to fix it. It's provided completely as-is; if something breaks, you lose data, or something else bad happens, the author(s) and owner(s) of this plugin are in no way responsible.

--- a/embedder/EmbedderPlugin.php
+++ b/embedder/EmbedderPlugin.php
@@ -13,7 +13,7 @@ class EmbedderPlugin extends BasePlugin
 
     public function getVersion()
     {
-        return '0.9.2';
+        return '0.9.3';
     }
 
     public function getDeveloper()

--- a/embedder/services/EmbedderService.php
+++ b/embedder/services/EmbedderService.php
@@ -59,6 +59,10 @@ class EmbedderService extends BaseApplicationComponent
         $viddler_type = (isset($params['viddler_type'])) ? "&type=" . $params['viddler_type'] : "";
         $viddler_ratio = (isset($params['viddler_ratio'])) ? "&ratio=" . $params['viddler_ratio'] : "";
 
+        // optional Wistia parameters
+        $wistia_type = (isset($params['wistia_type'])) ? "&embedType=" . $params['wistia_type'] : "";
+        $wistia_foam = (isset($params['wistia_foam']) && $params['wistia_foam'] == "true") ? "&videoFoam=true" : "";
+
         // automatically handle scheme if https
         $is_https = false;
         if (isset($params['force_https']) && $params['force_https'] == "true" || parse_url($video_url, PHP_URL_SCHEME) == 'https') {
@@ -78,7 +82,7 @@ class EmbedderService extends BaseApplicationComponent
             return $video_data;
         }
 
-        $url .= urlencode($video_url) . $max_width . $max_height . $wmode_param . $vimeo_byline . $vimeo_title . $vimeo_autoplay . $vimeo_portrait . $vimeo_api . $vimeo_player_id_str . $vimeo_color . $viddler_type . $viddler_ratio;
+        $url .= urlencode($video_url) . $max_width . $max_height . $wmode_param . $vimeo_byline . $vimeo_title . $vimeo_autoplay . $vimeo_portrait . $vimeo_api . $vimeo_player_id_str . $vimeo_color . $viddler_type . $viddler_ratio . $wistia_type . $wistia_foam;
 
         // checking if url has been cached
         $cached_url = craft()->fileCache->get($video_url);


### PR DESCRIPTION
Added support for Wistia's embedType and videoFoam parameters.

By default Wistia embeds videos via iframe, but the 'embedType' parameter gives you the option to choose a different method like 'seo' to make video content visible to search robots.

Also added the 'videoFoam' parameter that makes embedded videos behave fluid / responsive when set 'true'
